### PR TITLE
Set ShareTests to compatible FrameworkVersion

### DIFF
--- a/src/client/AM.PA.MonitoringTool/SharedTests/SharedTests.csproj
+++ b/src/client/AM.PA.MonitoringTool/SharedTests/SharedTests.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SharedTests</RootNamespace>
     <AssemblyName>SharedTests</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">15.0</VisualStudioVersion>


### PR DESCRIPTION
The whole solution is (still) being built with v4.5, so the tests should match that.